### PR TITLE
Add Terraform modules and docs

### DIFF
--- a/iac/terraform/.terraform.lock.hcl
+++ b/iac/terraform/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.5.0"
+  hashes = [
+    "h1:Tn/mGUS27xOhYi1yGXJfQXQtScNvyuTjd49KX5ZjhBM=",
+    "zh:0257c2719dc8508bc3ef5ac8df3c84b3ef61211ec46b6e5ed951681bbfe08d22",
+    "zh:3828d4409e2a68fccc9f9fb583167501cc4d38a5ecbb2408cb5781096739311b",
+    "zh:3cf7062a4a2530c2137473cc4281fd088cfe0059ad8cdb766e2083ac02c85aa9",
+    "zh:44c2caadd5d3ad4a69a646251319cce406c9800b2b823c2c59e8b0a3ea73fabd",
+    "zh:4924d88dbb45c9a01dc69323f731b969c2562631832509525ad44331e3682f43",
+    "zh:5ff081d29aaeb160753f7ba412d218dfd8703f2aeb0bc6cebe5f91c94bf1376a",
+    "zh:6d3f2c29b3c51629cb9ea2b513a981fb98226c69eeda670bb4d2b5cd0af8d278",
+    "zh:7df20d6ce088b131501f5dae9c3de763f81ac266000c19d4d53be79f568ecd24",
+    "zh:93c1ecaeedbc76b28297480d6456c6e65d80c72a20f6e870e537d7d80531c911",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ae8197c75460e25a664e76c183de79b798a82f31dcd99b44c6af2fd3ef249f5f",
+    "zh:aeacc428aa1f99a55432c969fb636dc6fc3346c6a95ebdcc5a240c222fbf0504",
+    "zh:be6d310269605985a8cf1d4d7984f3199b183dfc8cb3674c286c5bcfd4de7eb4",
+    "zh:c3ecd7a38af22d32479bcbca3c74c53969d71665ad4203b3102cbf519d6ddee7",
+    "zh:de127f5130604540b2be99c6b8b8253f4694a0a827cc9d186d72b545f27c45a5",
+  ]
+}

--- a/iac/terraform/README.md
+++ b/iac/terraform/README.md
@@ -1,0 +1,94 @@
+# Terraform Modules
+
+This folder defines the AWS infrastructure used for the project. The code is organised into small modules so each service can be deployed independently or reused.
+
+## Backend configuration
+
+Terraform state is stored remotely using an S3 bucket and DynamoDB table for locking:
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket         = "stp-tfstate"
+    key            = "prod/terraform.tfstate"
+    region         = "ap-southeast-2"
+    dynamodb_table = "stp-tfstate-lock"
+    encrypt        = true
+  }
+}
+```
+
+Initialise the backend with `terraform init`.
+
+## Variables
+
+The root module exposes a number of variables used by the modules:
+
+| Name | Description | Default |
+| ---- | ----------- | ------- |
+| `region` | AWS region to deploy into | `ap-southeast-2` |
+| `data_lake_bucket` | Name of the S3 bucket for the lake | n/a |
+| `msk_cluster_name` | Name of the MSK cluster | n/a |
+| `kafka_version` | Kafka version for MSK | `3.4.0` |
+| `broker_instance_type` | Broker EC2 instance type | `kafka.m5.large` |
+| `number_of_broker_nodes` | Number of MSK brokers | `2` |
+| `subnet_ids` | Subnets used by MSK and MWAA | n/a |
+| `security_group_ids` | Security groups applied to resources | n/a |
+| `emr_application_name` | EMR Serverless application name | n/a |
+| `mwaa_env_name` | Name of the MWAA environment | n/a |
+| `mwaa_dag_s3_path` | S3 prefix where DAGs are stored | n/a |
+| `mwaa_execution_role_arn` | IAM role ARN for MWAA | n/a |
+
+Values can be provided via `terraform.tfvars` files for each environment.
+
+## Module usage
+
+Each service has its own module under `modules/`.
+
+### S3
+
+```hcl
+module "s3" {
+  source      = "./modules/s3"
+  bucket_name = var.data_lake_bucket
+}
+```
+
+### MSK
+
+```hcl
+module "msk" {
+  source                 = "./modules/msk"
+  cluster_name           = var.msk_cluster_name
+  kafka_version          = var.kafka_version
+  broker_instance_type   = var.broker_instance_type
+  number_of_broker_nodes = var.number_of_broker_nodes
+  subnet_ids             = var.subnet_ids
+  security_group_ids     = var.security_group_ids
+}
+```
+
+### EMR Serverless
+
+```hcl
+module "emr" {
+  source           = "./modules/emr"
+  application_name = var.emr_application_name
+  release_label    = var.kafka_version
+}
+```
+
+### MWAA
+
+```hcl
+module "mwaa" {
+  source              = "./modules/mwaa"
+  env_name            = var.mwaa_env_name
+  dag_s3_path         = var.mwaa_dag_s3_path
+  execution_role_arn  = var.mwaa_execution_role_arn
+  network_subnet_ids  = var.subnet_ids
+  security_group_ids  = var.security_group_ids
+}
+```
+
+Run `terraform plan` to review the changes and `terraform apply` to create the infrastructure.

--- a/iac/terraform/main.tf
+++ b/iac/terraform/main.tf
@@ -3,5 +3,35 @@ terraform {
 }
 
 provider "aws" {
-  region = "ap-southeast-2"
+  region = var.region
+}
+
+module "s3" {
+  source      = "./modules/s3"
+  bucket_name = var.data_lake_bucket
+}
+
+module "msk" {
+  source                 = "./modules/msk"
+  cluster_name           = var.msk_cluster_name
+  kafka_version          = var.kafka_version
+  broker_instance_type   = var.broker_instance_type
+  number_of_broker_nodes = var.number_of_broker_nodes
+  subnet_ids             = var.subnet_ids
+  security_group_ids     = var.security_group_ids
+}
+
+module "emr" {
+  source           = "./modules/emr"
+  application_name = var.emr_application_name
+  release_label    = var.kafka_version
+}
+
+module "mwaa" {
+  source             = "./modules/mwaa"
+  env_name           = var.mwaa_env_name
+  dag_s3_path        = var.mwaa_dag_s3_path
+  execution_role_arn = var.mwaa_execution_role_arn
+  network_subnet_ids = var.subnet_ids
+  security_group_ids = var.security_group_ids
 }

--- a/iac/terraform/modules/emr/main.tf
+++ b/iac/terraform/modules/emr/main.tf
@@ -1,0 +1,8 @@
+resource "aws_emrserverless_application" "this" {
+  name          = var.application_name
+  release_label = var.release_label
+}
+
+output "application_id" {
+  value = aws_emrserverless_application.this.id
+}

--- a/iac/terraform/modules/emr/variables.tf
+++ b/iac/terraform/modules/emr/variables.tf
@@ -1,0 +1,10 @@
+variable "application_name" {
+  description = "Name of the EMR Serverless application"
+  type        = string
+}
+
+variable "release_label" {
+  description = "EMR release label"
+  type        = string
+  default     = "emr-6.10.0"
+}

--- a/iac/terraform/modules/msk/main.tf
+++ b/iac/terraform/modules/msk/main.tf
@@ -1,0 +1,15 @@
+resource "aws_msk_cluster" "this" {
+  cluster_name           = var.cluster_name
+  kafka_version          = var.kafka_version
+  number_of_broker_nodes = var.number_of_broker_nodes
+
+  broker_node_group_info {
+    instance_type   = var.broker_instance_type
+    client_subnets  = var.subnet_ids
+    security_groups = var.security_group_ids
+  }
+}
+
+output "cluster_arn" {
+  value = aws_msk_cluster.this.arn
+}

--- a/iac/terraform/modules/msk/variables.tf
+++ b/iac/terraform/modules/msk/variables.tf
@@ -1,0 +1,32 @@
+variable "cluster_name" {
+  description = "Name of the MSK cluster"
+  type        = string
+}
+
+variable "kafka_version" {
+  description = "Kafka version"
+  type        = string
+  default     = "3.4.0"
+}
+
+variable "broker_instance_type" {
+  description = "MSK broker instance type"
+  type        = string
+  default     = "kafka.m5.large"
+}
+
+variable "number_of_broker_nodes" {
+  description = "Number of MSK brokers"
+  type        = number
+  default     = 2
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs for MSK brokers"
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "Security groups for MSK"
+  type        = list(string)
+}

--- a/iac/terraform/modules/mwaa/main.tf
+++ b/iac/terraform/modules/mwaa/main.tf
@@ -1,0 +1,14 @@
+resource "aws_mwaa_environment" "this" {
+  name               = var.env_name
+  dag_s3_path        = var.dag_s3_path
+  execution_role_arn = var.execution_role_arn
+
+  network_configuration {
+    security_group_ids = var.security_group_ids
+    subnet_ids         = var.network_subnet_ids
+  }
+}
+
+output "arn" {
+  value = aws_mwaa_environment.this.arn
+}

--- a/iac/terraform/modules/mwaa/variables.tf
+++ b/iac/terraform/modules/mwaa/variables.tf
@@ -1,0 +1,24 @@
+variable "env_name" {
+  description = "Name of the MWAA environment"
+  type        = string
+}
+
+variable "dag_s3_path" {
+  description = "S3 path for DAGs"
+  type        = string
+}
+
+variable "execution_role_arn" {
+  description = "IAM role ARN used by MWAA"
+  type        = string
+}
+
+variable "network_subnet_ids" {
+  description = "Subnet IDs for MWAA"
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "Security groups for MWAA"
+  type        = list(string)
+}

--- a/iac/terraform/modules/s3/main.tf
+++ b/iac/terraform/modules/s3/main.tf
@@ -1,0 +1,7 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+}
+
+output "bucket_name" {
+  value = aws_s3_bucket.this.bucket
+}

--- a/iac/terraform/modules/s3/variables.tf
+++ b/iac/terraform/modules/s3/variables.tf
@@ -1,0 +1,4 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket"
+  type        = string
+}

--- a/iac/terraform/variables.tf
+++ b/iac/terraform/variables.tf
@@ -1,0 +1,63 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "ap-southeast-2"
+}
+
+variable "data_lake_bucket" {
+  description = "S3 bucket for the data lake"
+  type        = string
+}
+
+variable "msk_cluster_name" {
+  description = "MSK cluster name"
+  type        = string
+}
+
+variable "kafka_version" {
+  description = "Kafka version"
+  type        = string
+  default     = "3.4.0"
+}
+
+variable "broker_instance_type" {
+  description = "MSK broker instance type"
+  type        = string
+  default     = "kafka.m5.large"
+}
+
+variable "number_of_broker_nodes" {
+  description = "Number of MSK brokers"
+  type        = number
+  default     = 2
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs used for networking"
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "Security groups for networking"
+  type        = list(string)
+}
+
+variable "emr_application_name" {
+  description = "Name of the EMR Serverless application"
+  type        = string
+}
+
+variable "mwaa_env_name" {
+  description = "MWAA environment name"
+  type        = string
+}
+
+variable "mwaa_dag_s3_path" {
+  description = "S3 path to MWAA DAGs"
+  type        = string
+}
+
+variable "mwaa_execution_role_arn" {
+  description = "IAM role ARN used by MWAA"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- scaffold Terraform modules for S3, MSK, EMR and MWAA
- call the modules from the root configuration
- document backend config, variables and module usage

## Testing
- `flake8 ingest spark_jobs`
- `dbt deps`
- `dbt run -m +fact_trip_punctuality` *(fails: Invalid value for '--profiles-dir')*
- `terraform fmt -check`
- `terraform init`

