### PR TITLE
Add GTFS static fetcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+DATE ?= $(shell date +%Y%m%d)
+
+.PHONY: fetch_gtfs_static
+fetch_gtfs_static:
+	python scripts/fetch_gtfs_static.py $(DATE)
+

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ API access requires registering an app key with [TfNSW Open Data](https://openda
 
    ```bash
    make fetch_gtfs_static          # downloads & pushes to MinIO s3://stp/gtfs_static/
+   # DATE=20240101 make fetch_gtfs_static  # optional override
    ```
 4. **Start streaming**
 

--- a/ingest/requirements.txt
+++ b/ingest/requirements.txt
@@ -3,3 +3,4 @@ protobuf
 grpcio
 kafka-python
 python-dotenv
+boto3

--- a/scripts/fetch_gtfs_static.py
+++ b/scripts/fetch_gtfs_static.py
@@ -1,0 +1,39 @@
+import os
+import sys
+from datetime import date
+import requests
+import boto3
+
+
+def main():
+    day = sys.argv[1] if len(sys.argv) > 1 else date.today().strftime('%Y%m%d')
+    api_key = os.getenv('TFNSW_API_KEY')
+    if not api_key:
+        raise RuntimeError('TFNSW_API_KEY not set')
+
+    url = f'https://api.transport.nsw.gov.au/v1/gtfs/schedule/{day}'
+    headers = {'Authorization': f'apikey {api_key}'}
+    resp = requests.get(url, headers=headers, timeout=60)
+    resp.raise_for_status()
+
+    filename = f'gtfs_{day}.zip'
+    with open(filename, 'wb') as f:
+        f.write(resp.content)
+
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=os.getenv("MINIO_ENDPOINT", "http://localhost:9000"),
+        aws_access_key_id=os.getenv(
+            "MINIO_ROOT_USER", os.getenv("AWS_ACCESS_KEY_ID")
+        ),
+        aws_secret_access_key=os.getenv(
+            "MINIO_ROOT_PASSWORD", os.getenv("AWS_SECRET_ACCESS_KEY")
+        ),
+        region_name="us-east-1",
+    )
+    s3.upload_file(filename, 'stp', f'gtfs_static/{day}.zip')
+    print(f'Uploaded {filename} to s3://stp/gtfs_static/{day}.zip')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add script to download GTFS static snapshot and upload to MinIO
- expose `fetch_gtfs_static` target via Makefile
- document usage in README
- include boto3 in requirements

## Testing
- `flake8 ingest spark_jobs scripts`

------
https://chatgpt.com/codex/tasks/task_e_688367c642188329a1818e98964d2206