### PR TITLE
Add bus expectation suite

### DIFF
--- a/great_expectations/expectations/bus.expectation_suite.yml
+++ b/great_expectations/expectations/bus.expectation_suite.yml
@@ -1,0 +1,27 @@
+expectation_suite_name: bus.expectation_suite
+expectations:
+  - expectation_type: expect_column_values_to_not_be_null
+    kwargs:
+      column: latitude
+  - expectation_type: expect_column_values_to_be_between
+    kwargs:
+      column: latitude
+      min_value: -90
+      max_value: 90
+  - expectation_type: expect_column_values_to_not_be_null
+    kwargs:
+      column: longitude
+  - expectation_type: expect_column_values_to_be_between
+    kwargs:
+      column: longitude
+      min_value: -180
+      max_value: 180
+  - expectation_type: expect_column_values_to_be_between
+    kwargs:
+      column: delay_sec
+      min_value: 0
+  - expectation_type: expect_table_row_count_to_be_greater_than
+    kwargs:
+      value: 0
+meta:
+  notes: Minimal checks per README

--- a/great_expectations/great_expectations.yml
+++ b/great_expectations/great_expectations.yml
@@ -1,6 +1,13 @@
 # minimal Great Expectations config
-store_backend_defaults:
-  class_name: InMemoryStoreBackendDefaults
+config_version: 3
+stores:
+  expectations_store:
+    class_name: ExpectationsStore
+    store_backend:
+      class_name: TupleFilesystemStoreBackend
+      base_directory: great_expectations/expectations/
+
+expectations_store_name: expectations_store
 
 data_docs_sites:
   local_site:


### PR DESCRIPTION
## Summary
- configure GE to store expectation suites on disk
- add a `bus.expectation_suite` covering latitude, longitude, delay_sec and row count

## Testing
- `flake8 ingest spark_jobs`
- `DBT_PROFILES_DIR=profiles dbt run -m +fact_trip_punctuality`
- `DBT_PROFILES_DIR=profiles dbt test` *(no tests run)*
- `GX_HOME=$(pwd)/great_expectations great_expectations checkpoint list`
- `GX_HOME=$(pwd)/great_expectations great_expectations checkpoint run stp_bus` *(fails: Checkpoint configuration incomplete)*

