### PR TITLE
Fix bronze stream to run continuously

### DIFF
--- a/spark_jobs/bronze_stream.py
+++ b/spark_jobs/bronze_stream.py
@@ -19,9 +19,12 @@ stream_df = (
     .load()
 )
 
-(
+query = (
     stream_df.writeStream.format("iceberg")
     .outputMode("append")
     .option("checkpointLocation", "/tmp/checkpoints/bronze")
     .toTable("stp.bronze_bus_positions")
+    .start()
 )
+
+query.awaitTermination()


### PR DESCRIPTION
## Summary
- run `.writeStream.start()` so bronze stream doesn't exit immediately
- block execution with `awaitTermination`

## Testing
- `flake8 ingest spark_jobs`


------
https://chatgpt.com/codex/tasks/task_e_68836f0b57f88329858b5b83d97284f9