### PR TITLE
Add Superset dashboard JSON exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,11 +344,11 @@ jobs:
   1. **Map** – real‑time vehicle positions (point geo, auto‑refresh 15 s).
   2. **Delay by Hour** – heatmap of average delay minutes across hours × routes.
   3. **On‑time % trend** – line chart by day.
-* Dashboards exported → `superset/dashboard_export.json`.
-  To import this file into Superset:
+* Dashboards exported under `superset/`.
+  To import the JSON files:
   1. Log in as an admin user.
   2. Go to **Settings → Import Dashboards**.
-  3. Upload `superset/dashboard_export.json` and confirm.
+  3. Upload any file from `superset/` and confirm.
 
 ---
 

--- a/superset/dashboards/route_delay_dashboard.json
+++ b/superset/dashboards/route_delay_dashboard.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0.0",
+  "type": "dashboard",
+  "dashboard_title": "Route Delay Dashboard",
+  "charts": [
+    {
+      "slice_name": "Average Delay by Route",
+      "viz_type": "bar",
+      "params": {
+        "metrics": "avg_delay",
+        "groupby": "route",
+        "time_range": "No filter"
+      }
+    }
+  ],
+  "layout": {}
+}

--- a/superset/dashboards/vehicle_locations_dashboard.json
+++ b/superset/dashboards/vehicle_locations_dashboard.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0.0",
+  "type": "dashboard",
+  "dashboard_title": "Vehicle Locations Map",
+  "charts": [
+    {
+      "slice_name": "Vehicle Locations",
+      "viz_type": "map",
+      "params": {
+        "time_range": "No filter"
+      }
+    }
+  ],
+  "layout": {}
+}


### PR DESCRIPTION
## Summary
- add example Superset dashboard exports under `superset/dashboards`
- update README instructions for importing dashboards

## Testing
- `pip install -r ingest/requirements.txt`
- `pip install flake8`
- `flake8 ingest spark_jobs`

