### PR TITLE
Fix CI lint by including flake8

### DIFF
--- a/ingest/requirements.txt
+++ b/ingest/requirements.txt
@@ -4,3 +4,4 @@ grpcio
 kafka-python
 python-dotenv
 boto3
+flake8


### PR DESCRIPTION
## Summary
- ensure `flake8` is installed for linting

## Testing
- `flake8 ingest spark_jobs`
