### PR TITLE
Fix Bronze stream start

### DIFF
--- a/spark_jobs/bronze_stream.py
+++ b/spark_jobs/bronze_stream.py
@@ -24,7 +24,6 @@ query = (
     .outputMode("append")
     .option("checkpointLocation", "/tmp/checkpoints/bronze")
     .toTable("stp.bronze_bus_positions")
-    .start()
 )
 
 query.awaitTermination()


### PR DESCRIPTION
## Summary
- start `bronze_stream` using `toTable` and keep it running with `awaitTermination`

## Testing
- `poetry run pytest -q`
- `flake8 ingest spark_jobs`

------
https://chatgpt.com/codex/tasks/task_e_68837bef61088329a9121e12bdeeea35