### PR TITLE
Add basic GE suite

### DIFF
--- a/airflow/dags/pipeline.py
+++ b/airflow/dags/pipeline.py
@@ -37,7 +37,7 @@ dbt_run = BashOperator(
 
 ge_validate = BashOperator(
     task_id="ge_validate",
-    bash_command="cd /opt/airflow/great_expectations && great_expectations checkpoint run stp_bus",
+    bash_command="great_expectations -c /opt/airflow/great_expectations/great_expectations.yml checkpoint run stp_bus",
     dag=dag,
 )
 

--- a/great_expectations/checkpoints/stp_bus.yml
+++ b/great_expectations/checkpoints/stp_bus.yml
@@ -17,4 +17,4 @@ validations:
       datasource_name: stp
       data_connector_name: default_inferred_data_connector_name
       data_asset_name: silver_bus_positions
-    expectation_suite_name: bus_expectation_suite
+    expectation_suite_name: basic_expectation_suite

--- a/great_expectations/expectations/basic_expectation_suite.yml
+++ b/great_expectations/expectations/basic_expectation_suite.yml
@@ -1,0 +1,16 @@
+expectation_suite_name: basic_expectation_suite
+expectations:
+  - expectation_type: expect_column_values_to_not_be_null
+    kwargs:
+      column: latitude
+  - expectation_type: expect_column_values_to_not_be_null
+    kwargs:
+      column: longitude
+  - expectation_type: expect_column_values_to_not_be_null
+    kwargs:
+      column: delay_sec
+  - expectation_type: expect_table_row_count_to_be_between
+    kwargs:
+      min_value: 1
+meta:
+  notes: Basic sanity checks for demo dataset


### PR DESCRIPTION
## Summary
- add a simple expectation suite
- update checkpoint to use new suite
- run GE with explicit config in Airflow DAG

## Testing
- `flake8 ingest spark_jobs`
- `dbt deps`
- `dbt run -m +fact_trip_punctuality --profiles-dir profiles`
- `dbt test --profiles-dir profiles`


------
https://chatgpt.com/codex/tasks/task_e_68837ed749c08329a925a1f22ab12984