### PR TITLE
Fix Terraform job path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,22 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     environment: prod
+    defaults:
+      run:
+        working-directory: iac/terraform
+    env:
+      TF_VAR_data_lake_bucket: ${{ secrets.DATA_LAKE_BUCKET }}
+      TF_VAR_msk_cluster_name: ${{ secrets.MSK_CLUSTER_NAME }}
+      TF_VAR_subnet_ids: ${{ secrets.SUBNET_IDS }}
+      TF_VAR_security_group_ids: ${{ secrets.SECURITY_GROUP_IDS }}
+      TF_VAR_emr_application_name: ${{ secrets.EMR_APPLICATION_NAME }}
+      TF_VAR_mwaa_env_name: ${{ secrets.MWAA_ENV_NAME }}
+      TF_VAR_mwaa_dag_s3_path: ${{ secrets.MWAA_DAG_S3_PATH }}
+      TF_VAR_mwaa_execution_role_arn: ${{ secrets.MWAA_EXECUTION_ROLE_ARN }}
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
       - run: terraform fmt -check
       - run: terraform init
-      - run: terraform plan -out=tfplan
+      - run: terraform plan -input=false -out=tfplan
       - run: terraform apply -input=false tfplan

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,11 +4,23 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: iac/terraform
+    env:
+      TF_VAR_data_lake_bucket: ${{ secrets.DATA_LAKE_BUCKET }}
+      TF_VAR_msk_cluster_name: ${{ secrets.MSK_CLUSTER_NAME }}
+      TF_VAR_subnet_ids: ${{ secrets.SUBNET_IDS }}
+      TF_VAR_security_group_ids: ${{ secrets.SECURITY_GROUP_IDS }}
+      TF_VAR_emr_application_name: ${{ secrets.EMR_APPLICATION_NAME }}
+      TF_VAR_mwaa_env_name: ${{ secrets.MWAA_ENV_NAME }}
+      TF_VAR_mwaa_dag_s3_path: ${{ secrets.MWAA_DAG_S3_PATH }}
+      TF_VAR_mwaa_execution_role_arn: ${{ secrets.MWAA_EXECUTION_ROLE_ARN }}
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
       - run: terraform init
-      - run: terraform plan -out=tfplan
+      - run: terraform plan -input=false -out=tfplan
       - run: terraform apply -input=false tfplan
       - name: dbt docs
         run: |


### PR DESCRIPTION
## Summary
- run Terraform commands inside `iac/terraform`
- set TF_VAR secrets so Terraform won't block on input
- run plan with `-input=false`

## Testing
- `flake8 ingest spark_jobs`
- `cd dbt && dbt deps && dbt run -m +fact_trip_punctuality --profiles-dir profiles && dbt test --profiles-dir profiles`
- `terraform init -backend=false`


------
https://chatgpt.com/codex/tasks/task_e_6883841138248329a14256ebac65953b