### PR TITLE
Add example Grafana dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,12 @@ jobs:
   * *Pipeline Health* – DAG duration, task success ratio.
   * *Bus Delay Heatmap* – real‑time average delay by route/hour.
   * *Infrastructure* – MSK broker CPU, EMR cost.
+  
+  Example JSON exports are provided under `monitoring/grafana/dashboards/`.
+  To load them into Grafana:
+  1. Open the Grafana web UI.
+  2. Navigate to **Create → Import**.
+  3. Upload any dashboard JSON file from that directory and confirm.
 * **Alerts**
 
   * Slack alert if `ge_validate` fails.

--- a/monitoring/grafana/dashboards/bus_delay_heatmap.json
+++ b/monitoring/grafana/dashboards/bus_delay_heatmap.json
@@ -1,0 +1,12 @@
+{
+  "title": "Bus Delay Heatmap",
+  "uid": "bus_delay_heatmap",
+  "version": 1,
+  "panels": [
+    {
+      "type": "heatmap",
+      "title": "Average Delay by Hour",
+      "targets": [{"expr": "avg_delay_minutes{job=\"bus\"}"}]
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/infrastructure.json
+++ b/monitoring/grafana/dashboards/infrastructure.json
@@ -1,0 +1,17 @@
+{
+  "title": "Infrastructure",
+  "uid": "infrastructure",
+  "version": 1,
+  "panels": [
+    {
+      "type": "graph",
+      "title": "MSK Broker CPU",
+      "targets": [{"expr": "avg(rate(node_cpu_seconds_total{job=\"msk\",mode=\"user\"}[5m]))"}]
+    },
+    {
+      "type": "graph",
+      "title": "EMR Cost",
+      "targets": [{"expr": "sum(emr_cost_daily)"}]
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/pipeline_health.json
+++ b/monitoring/grafana/dashboards/pipeline_health.json
@@ -1,0 +1,17 @@
+{
+  "title": "Pipeline Health",
+  "uid": "pipeline_health",
+  "version": 1,
+  "panels": [
+    {
+      "type": "graph",
+      "title": "DAG Duration",
+      "targets": [{"expr": "airflow_dag_run_duration"}]
+    },
+    {
+      "type": "graph",
+      "title": "Task Success Ratio",
+      "targets": [{"expr": "airflow_task_success_ratio"}]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add example Grafana dashboard JSON files
- mention how to import Grafana dashboards in README

## Testing
- `flake8 ingest spark_jobs`
- `dbt run -m +fact_trip_punctuality --profiles-dir profiles`
- `dbt test --profiles-dir profiles`

