### PR TITLE
fix: pass network configuration variables to terraform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
       TF_VAR_mwaa_dag_s3_path: ${{ secrets.MWAA_DAG_S3_PATH }}
       TF_VAR_mwaa_execution_role_arn: ${{ secrets.MWAA_EXECUTION_ROLE_ARN }}
       TF_VAR_mwaa_source_bucket_arn: ${{ secrets.MWAA_SOURCE_BUCKET_ARN }}
-      TF_VAR_network_subnet_ids: >-
+      TF_VAR_subnet_ids: >-
         ["${{ secrets.SUBNET_IDS//,/"," }}"]
       TF_VAR_security_group_ids: >-
-        ["${{ secrets.SECURITY_GROUP_IDS }}"]
+        ["${{ secrets.SECURITY_GROUP_IDS//,/"," }}"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- pass subnet and security group IDs to Terraform with correct variable names

## Testing
- `terraform fmt -check`
- `terraform init`
- `terraform plan -input=false -out=tfplan` *(fails: The security token included in the request is invalid)*
- `flake8 ingest spark_jobs`
- `dbt deps`
- `dbt run -m +fact_trip_punctuality --profiles-dir profiles`
- `dbt test --profiles-dir profiles`

